### PR TITLE
Allow to provide an Uint8Array rather than a string in stdin

### DIFF
--- a/src/fn.ts
+++ b/src/fn.ts
@@ -2,6 +2,10 @@ export function isString(s?: string | unknown): s is string {
   return typeof s === "string";
 }
 
+export function isUint8Array(s?: Uint8Array | unknown): s is Uint8Array {
+  return typeof s === "Uint8Array";
+}
+
 const decoder = new TextDecoder();
 
 export function asString(buf: Uint8Array | null | undefined): string {

--- a/src/fn.ts
+++ b/src/fn.ts
@@ -3,7 +3,7 @@ export function isString(s?: string | unknown): s is string {
 }
 
 export function isUint8Array(s?: Uint8Array | unknown): s is Uint8Array {
-  return typeof s === "Uint8Array";
+  return s instanceof Uint8Array;
 }
 
 const decoder = new TextDecoder();

--- a/src/run.ts
+++ b/src/run.ts
@@ -44,7 +44,7 @@ export class CommandFailureError extends Error implements CommandFailure {
 export interface RunOptions
   extends Omit<Deno.CommandOptions, "args" | "stdin" | "stdout" | "stderr"> {
   /** If specified, will be supplied as STDIN to the command. */
-  stdin?: string;
+  stdin?: string | Uint8Array;
   /** Print extra details to STDERR; default to whether env variable `"VERBOSE"` has a truthy value, and `--allow-env` is enabled. */
   verbose?: boolean;
 }
@@ -59,7 +59,7 @@ async function tryRun(
 ): Promise<string> {
   options = { ...defaultRunOptions, ...options };
 
-  const pipeStdIn = isString(options.stdin);
+  const pipeStdIn = isString(options.stdin) || isUint8Array(options.stdin);
 
   if (options.verbose) {
     console.error(`
@@ -80,7 +80,7 @@ ${j({ cmd, options })}
   const process: Deno.ChildProcess = command.spawn();
 
   if (pipeStdIn) {
-    const stdinBuf: Uint8Array = new TextEncoder().encode(options.stdin);
+    const stdinBuf: Uint8Array = isString(options.stdin) ? new TextEncoder().encode(options.stdin) : options.stdin;
     const writer = process.stdin.getWriter();
     try {
       await writer.write(stdinBuf);

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,4 +1,4 @@
-import { asString, isString, j, omit, parseJsonSafe } from "./fn.ts";
+import { asString, isString, isUint8Array, j, omit, parseJsonSafe } from "./fn.ts";
 import { weakEnvGet } from "./os.ts";
 
 /** Item in the command array. */
@@ -79,7 +79,7 @@ ${j({ cmd, options })}
   const command: Deno.Command = new Deno.Command(executable, commandOptions);
   const process: Deno.ChildProcess = command.spawn();
 
-  if (pipeStdIn) {
+  if (options.stdin && pipeStdIn) {
     const stdinBuf: Uint8Array = isString(options.stdin) ? new TextEncoder().encode(options.stdin) : options.stdin;
     const writer = process.stdin.getWriter();
     try {

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,4 +1,11 @@
-import { asString, isString, isUint8Array, j, omit, parseJsonSafe } from "./fn.ts";
+import {
+  asString,
+  isString,
+  isUint8Array,
+  j,
+  omit,
+  parseJsonSafe,
+} from "./fn.ts";
 import { weakEnvGet } from "./os.ts";
 
 /** Item in the command array. */
@@ -80,7 +87,9 @@ ${j({ cmd, options })}
   const process: Deno.ChildProcess = command.spawn();
 
   if (options.stdin && pipeStdIn) {
-    const stdinBuf: Uint8Array = isString(options.stdin) ? new TextEncoder().encode(options.stdin) : options.stdin;
+    const stdinBuf: Uint8Array = isString(options.stdin)
+      ? new TextEncoder().encode(options.stdin)
+      : options.stdin;
     const writer = process.stdin.getWriter();
     try {
       await writer.write(stdinBuf);


### PR DESCRIPTION
Hi,
I need to send a Uint8Array directly to the stdin of a Command, but since `new TextEncoder()` is quite heavy, I would like to avoid using it if possible.